### PR TITLE
fix: improve mobile submenu handling

### DIFF
--- a/src/header/categoryBar/categorybar.css
+++ b/src/header/categoryBar/categorybar.css
@@ -76,9 +76,6 @@
 }
 
 .custom-submenu {
-  position: fixed !important;
-  top: 56px !important; /* Ajuste conforme a altura da sua .category-bar */
-  left: 0 !important;
   background-color: #2e7d32 !important;
   z-index: 9999;
   width: max-content;

--- a/src/header/categoryBar/categorybar.js
+++ b/src/header/categoryBar/categorybar.js
@@ -9,6 +9,11 @@ const CategoryBar = () => {
   const [menuItems, setMenuItems] = useState([]);
   const menuRef = useRef(null);
 
+  const onOpenChange = (keys) => {
+    const latest = keys.find((key) => !openKeys.includes(key));
+    setOpenKeys(latest ? [latest] : []);
+  };
+
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 768);
     window.addEventListener("resize", handleResize);
@@ -78,7 +83,10 @@ const CategoryBar = () => {
       <Menu
         mode={isMobile ? "horizontal" : "inline"}
         theme="dark"
-        popupclassname="custom-submenu"
+        popupClassName="custom-submenu"
+        openKeys={openKeys}
+        onOpenChange={onOpenChange}
+        getPopupContainer={(trigger) => trigger.parentNode}
         style={{
           width: isMobile ? 'max-content' : "14vw",
           display: isMobile ? "flex" : "block",


### PR DESCRIPTION
## Summary
- close previously opened mobile submenus when opening another
- anchor submenu position to menu and update styling

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'swiper/react')*


------
https://chatgpt.com/codex/tasks/task_e_68b5cc4462348322965aa4f019410ff4