### PR TITLE
refactor: centralize header offset variable

### DIFF
--- a/src/header/categoryBar/categorybar.css
+++ b/src/header/categoryBar/categorybar.css
@@ -1,5 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 
+:root {
+  --header-offset: 114px;
+}
+
 .category-bar-up {
   transform: translateX(-260px);
   transition: transform 0.4s ease-in-out;
@@ -7,10 +11,10 @@
 
 .category-bar {
   position: fixed;
-  top: 114px;
+  top: var(--header-offset);
   left: 0;
   width: 270px;
-  height: calc(100vh - 114px);
+  height: calc(100vh - var(--header-offset));
   background-color: #1c1c1c; /* Preto suave, estilo zen */
   box-shadow: 3px 0 6px rgba(0, 0, 0, 0.2);
   z-index: 998;
@@ -92,11 +96,15 @@
 @media (max-width: 768px) {
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 
+  :root {
+    --header-offset: 120px;
+  }
+
   /* Estilo base para a barra no mobile */
   .category-bar {
     position: fixed;
     width: 100vw;
-    height: 7vh;
+    height: calc(100vh - var(--header-offset));
     background-color: #1c1c1c; /* Preto suave */
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
     z-index: 998;
@@ -108,7 +116,7 @@
     flex-direction: row;
     gap: 12px;
     scroll-behavior: smooth;
-    top: 120px; /* mantém a margem superior igual ao desktop */
+    top: var(--header-offset);
     left: 0;
   }
 
@@ -193,17 +201,10 @@
     outline: 2px solid #e9e5dc;
     outline-offset: 2px;
   }
-
-  /* altura do header fixo (desktop e mobile) */
-:root { --header-offset: 150px; }
-@media (max-width: 768px) {
-  :root { --header-offset: 210px; }
 }
 
 /* garante que a âncora não fique escondida pelo header */
 .content-section {
   scroll-margin-top: var(--header-offset);
-}
-
 }
 


### PR DESCRIPTION
## Summary
- use CSS variable for header offset and override on mobile
- set category bar top/height based on header offset
- remove nested media query and adjust scroll-margin

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'swiper/react')*

------
https://chatgpt.com/codex/tasks/task_e_68baece874888322b8e1e4d4fce865e7